### PR TITLE
Build: Set javac release property (ticket #2775)

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,10 +1,10 @@
 I2P source installation instructions
 
 Prerequisites to build from source:
-	Java SDK (preferably Oracle/Sun or OpenJDK) 1.8.0 or higher
+	Java SDK (preferably Oracle or OpenJDK) 8 or higher
           Non-linux operating systems and JVMs: See https://trac.i2p2.de/wiki/java
           Certain subsystems for embedded (core, router, mstreaming, streaming, i2ptunnel) require only Java 1.6
-	Apache Ant 1.7.0 or higher
+	Apache Ant 1.9.8 or higher
 	The xgettext, msgfmt, and msgmerge tools installed
 	  from the GNU gettext package http://www.gnu.org/software/gettext/
 	Build environment must use a UTF-8 locale.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To get development branch from source control: https://gitlab.com/i2p.plus/I2P.P
   - Non-linux operating systems and JVMs: See https://trac.i2p2.de/wiki/java
   - Certain subsystems for embedded (core, router, mstreaming, streaming, i2ptunnel)
     require only Java 1.6
-- Apache Ant 1.7.0 or higher
+- Apache Ant 1.9.8 or higher
 - The xgettext, msgfmt, and msgmerge tools installed from the GNU gettext package
   http://www.gnu.org/software/gettext/
 - Build environment must use a UTF-8 locale.

--- a/README.txt
+++ b/README.txt
@@ -1,8 +1,8 @@
 Prerequisites to build from source:
-	Java SDK (preferably Oracle/Sun or OpenJDK) 1.8.0 or higher
+	Java SDK (preferably Oracle or OpenJDK) 8 or higher
           Non-linux operating systems and JVMs: See https://trac.i2p2.de/wiki/java
-          Certain subsystems for embedded (core, router, mstreaming, streaming, i2ptunnel) require only Java 1.6
-	Apache Ant 1.7.0 or higher
+          Certain subsystems for embedded (core, router, mstreaming, streaming, i2ptunnel) require only Java 6
+	Apache Ant 1.9.8 or higher
 	The xgettext, msgfmt, and msgmerge tools installed
 	  from the GNU gettext package http://www.gnu.org/software/gettext/
 	Build environment must use a UTF-8 locale.

--- a/apps/BOB/nbproject/build-impl.xml
+++ b/apps/BOB/nbproject/build-impl.xml
@@ -39,8 +39,9 @@ is divided into following sections:
         <property file="${user.properties.file}"/>
         <!-- The two properties below are usually overridden -->
         <!-- by the active platform. Just a fallback. -->
-        <property name="default.javac.source" value="1.4"/>
-        <property name="default.javac.target" value="1.4"/>
+        <property name="default.javac.source" value="1.8"/>
+        <property name="default.javac.target" value="1.8"/>
+        <property name="javac.release" value="8"/>
     </target>
     <target depends="-pre-init,-init-private,-init-user" name="-init-project">
         <property file="nbproject/configs/${config}.properties"/>
@@ -155,7 +156,7 @@ is divided into following sections:
             <attribute default="/does/not/exist" name="sourcepath"/>
             <element name="customize" optional="true"/>
             <sequential>
-                <javac debug="@{debug}" deprecation="${javac.deprecation}" destdir="@{destdir}" encoding="${source.encoding}" excludes="@{excludes}" includeantruntime="false" includes="@{includes}" source="${javac.source}" sourcepath="@{sourcepath}" srcdir="@{srcdir}" target="${javac.target}">
+                <javac debug="@{debug}" deprecation="${javac.deprecation}" destdir="@{destdir}" encoding="${source.encoding}" excludes="@{excludes}" includeantruntime="false" includes="@{includes}" source="${javac.source}" sourcepath="@{sourcepath}" srcdir="@{srcdir}" target="${javac.target}" release="${javac.release}">
                     <classpath>
                         <path path="@{classpath}"/>
                     </classpath>

--- a/apps/BOB/nbproject/project.properties
+++ b/apps/BOB/nbproject/project.properties
@@ -29,28 +29,19 @@ endorsed.classpath=
 excludes=**/*.html,**/*.txt
 file.reference.build-javadoc=../../i2p.i2p/build/javadoc
 file.reference.i2p.jar=../../core/java/build/i2p.jar
-file.reference.i2ptunnel.jar=../i2ptunnel/java/build/i2ptunnel.jar
-file.reference.jbigi.jar=../../build/jbigi.jar
 file.reference.mstreaming.jar=../ministreaming/java/build/mstreaming.jar
-file.reference.router.jar=../../router/java/build/router.jar
-file.reference.streaming.jar=../streaming/java/build/streaming.jar
-file.reference.wrapper.jar=../../installer/lib/wrapper/all/wrapper.jar
 includes=**
 jar.compress=true
 javac.classpath=\
-    ${file.reference.router.jar}:\
-    ${file.reference.i2ptunnel.jar}:\
     ${file.reference.mstreaming.jar}:\
-    ${file.reference.streaming.jar}:\
-    ${file.reference.wrapper.jar}:\
-    ${file.reference.i2p.jar}:\
-    ${file.reference.router.jar}
+    ${file.reference.i2p.jar}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.version=1.7
+javac.version=1.8
 javac.source=${javac.version}
 javac.target=${javac.version}
+javac.release=8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\

--- a/apps/BOB/nbproject/project.xml
+++ b/apps/BOB/nbproject/project.xml
@@ -4,7 +4,7 @@
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/j2se-project/3">
             <name>BOB</name>
-            <minimum-ant-version>1.6.5</minimum-ant-version>
+            <minimum-ant-version>1.9.8</minimum-ant-version>
             <source-roots>
                 <root id="src.dir"/>
             </source-roots>

--- a/apps/addressbook/build.xml
+++ b/apps/addressbook/build.xml
@@ -8,6 +8,7 @@
 	<property name="war" value="addressbook.war"/>
 	<property name="javac.compilerargs" value="" />
 	<property name="javac.version" value="1.8" />
+	<property name="javac.release" value="8" />
 
 	<target name="all" depends="jar, emptyWar"/> 
 	
@@ -40,6 +41,7 @@
 
 	<target name="compile" depends="init, depend, warUpToDate">
             <javac debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+                       release="${javac.release}"
                        includeAntRuntime="false"
                        encoding="UTF-8"
                        srcdir="${src}" destdir="${build}">

--- a/apps/desktopgui/build.xml
+++ b/apps/desktopgui/build.xml
@@ -8,6 +8,7 @@
 	<property name="javadoc" value="javadoc"/>
 	<property name="javac.compilerargs" value=""/>
 	<property name="javac.version" value="1.8" />
+	<property name="javac.release" value="8" />
 	<property name="require.gettext" value="true" />
 
     <condition property="no.bundle">
@@ -27,6 +28,7 @@
 
         <target name="compile" depends="init">
             <javac debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+                       release="${javac.release}"
                        includeAntRuntime="false"
                        encoding="UTF-8"
                        srcdir="${src}" destdir="${build}">
@@ -52,6 +54,7 @@
                 <arg value="./bundle-messages.sh" />
             </exec>
             <javac source="${javac.version}" target="${javac.version}" 
+                   release="${javac.release}"
                    includeAntRuntime="false"
                    encoding="UTF-8"
                    srcdir="${build}/messages-src" destdir="${build}">

--- a/apps/i2pcontrol/build.xml
+++ b/apps/i2pcontrol/build.xml
@@ -51,6 +51,7 @@
 
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="builddep" >
         <mkdir dir="./build" />
@@ -58,6 +59,7 @@
         <javac 
             srcdir="./java" 
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" 
@@ -77,6 +79,7 @@
             sourcepath=""
             srcdir="./java" 
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" 

--- a/apps/i2psnark/java/build.xml
+++ b/apps/i2psnark/java/build.xml
@@ -28,6 +28,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="require.gettext" value="true" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
@@ -38,10 +39,11 @@
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
         <mkdir dir="./build/obj" />
-        <javac
-            srcdir="./src"
-            debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
-            destdir="./build/obj"
+        <javac 
+            srcdir="./src" 
+            debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
+            destdir="./build/obj" 
             encoding="UTF-8"
             includeAntRuntime="false" >
             <compilerarg line="${javac.compilerargs}" />
@@ -164,6 +166,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="build/obj">

--- a/apps/i2ptunnel/java/build.xml
+++ b/apps/i2ptunnel/java/build.xml
@@ -29,6 +29,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="require.gettext" value="true" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
@@ -40,6 +41,7 @@
             srcdir="./src" 
             excludes="net/i2p/i2ptunnel/web/**/*"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             destdir="./build/obj" 
             includeAntRuntime="false"
             encoding="UTF-8"
@@ -56,6 +58,7 @@
             srcdir="./src" 
             includes="net/i2p/i2ptunnel/web/**/*"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             destdir="./build/obj" 
             includeAntRuntime="false"
             encoding="UTF-8"
@@ -167,6 +170,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="../jsp/WEB-INF/classes">
@@ -212,6 +216,7 @@
             <arg value="./bundle-messages-proxy.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-proxy-src" destdir="build/obj">
@@ -350,6 +355,7 @@
             <arg value="../jsp/" />
         </java>
         <javac debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                destdir="../jsp/WEB-INF/classes/" srcdir="../jsp/WEB-INF/classes" includes="**/*.java">
@@ -415,6 +421,7 @@
         <mkdir dir="./build/obj" />
         <!-- We need the ant runtime, as it includes junit -->
         <javac srcdir="./src:./test/junit" debug="true" source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="true"
                encoding="UTF-8"
                deprecation="on" destdir="./build/obj" >

--- a/apps/imagegen/identicon/build.xml
+++ b/apps/imagegen/identicon/build.xml
@@ -19,11 +19,13 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
         <mkdir dir="./build/obj" />
         <javac srcdir="./core/src/main/java" debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                destdir="./build/obj" >
@@ -37,6 +39,7 @@
         <javac
             srcdir="./test/junit"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./buildTest/obj"

--- a/apps/imagegen/imagegen/build.xml
+++ b/apps/imagegen/imagegen/build.xml
@@ -29,12 +29,14 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
         <mkdir dir="./build/WEB-INF" />
         <mkdir dir="./build/WEB-INF/classes" />
         <javac srcdir="./webapp/src/main/java" debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
  	       classpathref="cp"

--- a/apps/imagegen/zxing/build.xml
+++ b/apps/imagegen/zxing/build.xml
@@ -18,18 +18,21 @@
 
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="javac.compilerargs" value="" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
         <mkdir dir="./build/obj" />
         <javac srcdir="./core/src/main/java" debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                destdir="./build/obj" >
             <compilerarg line="${javac.compilerargs}" />
         </javac>
         <javac srcdir="./javase/src/main/java" debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                destdir="./build/obj" classpath="./build/obj" >
@@ -43,6 +46,7 @@
         <javac
             srcdir="./test/junit"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./buildTest/obj"

--- a/apps/jetty/build.xml
+++ b/apps/jetty/build.xml
@@ -23,6 +23,7 @@
     <property name="verified.filename" value="verified.txt" />
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
     <!-- everything we need is in the deployer package, except for tomcat-api.jar in the full package,
@@ -393,6 +394,7 @@
         <javac
             srcdir="./java/src"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             destdir="./build/obj"
             encoding="UTF-8"
             includeAntRuntime="false" >
@@ -476,6 +478,7 @@
         <javac
             srcdir="./patches/jetty-util/src/main/java"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             destdir="./build/objPatches"
             includeAntRuntime="false"
             encoding="UTF-8"

--- a/apps/jrobin/java/build.xml
+++ b/apps/jrobin/java/build.xml
@@ -19,6 +19,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
     <target name="compile" depends="depend">
@@ -30,6 +31,7 @@
             deprecation="on"
             source="${javac.version}"
             target="${javac.version}"
+            release="${javac.release}"
             destdir="./build/obj"
             includeAntRuntime="false"
             encoding="UTF-8"

--- a/apps/ministreaming/java/build.xml
+++ b/apps/ministreaming/java/build.xml
@@ -23,6 +23,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="require.gettext" value="true" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
@@ -35,6 +36,7 @@
         <mkdir dir="./build/obj" />
         <!-- half of this is deprecated classes so turn deprecation off -->
         <javac srcdir="./src" debug="true" deprecation="off" source="${javac.version}" target="${javac.version}"
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                destdir="./build/obj" classpath="../../../core/java/build/i2p.jar" >
@@ -48,6 +50,7 @@
         <javac
             srcdir="./demo"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./buildDemo/obj"
@@ -123,6 +126,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="build/obj">
@@ -238,6 +242,7 @@
         <javac
             srcdir="./test/junit"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" >

--- a/apps/routerconsole/java/build.xml
+++ b/apps/routerconsole/java/build.xml
@@ -49,6 +49,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
     <target name="compile" depends="prepare, depend, dependVersion">
@@ -57,6 +58,7 @@
         <javac 
             srcdir="./src" 
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj">
@@ -95,6 +97,7 @@
             srcdir="./src" 
             includes="net/i2p/router/news/*.java"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj">
@@ -178,6 +181,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="build/obj">
@@ -236,6 +240,7 @@
             <arg value="./bundle-messages-news.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-news-src" destdir="build/obj">
@@ -256,6 +261,7 @@
             <arg value="./bundle-messages-countries.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-countries-src" destdir="build/obj">
@@ -471,6 +477,7 @@
         </java>
         
         <javac debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                encoding="UTF-8"
                includeAntRuntime="false"
                destdir="../jsp/WEB-INF/classes/" 

--- a/apps/sam/java/build.xml
+++ b/apps/sam/java/build.xml
@@ -25,6 +25,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
     <!-- compile everything including client classes -->
@@ -34,6 +35,7 @@
         <javac 
             srcdir="./src" 
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" 
@@ -46,6 +48,7 @@
         <javac 
             srcdir="./test" 
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" 

--- a/apps/streaming/java/build.xml
+++ b/apps/streaming/java/build.xml
@@ -24,6 +24,7 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
@@ -31,6 +32,7 @@
         <javac
             srcdir="./src"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj"
@@ -60,6 +62,7 @@
         <javac
             srcdir="./test/junit"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" >

--- a/apps/susidns/src/build.xml
+++ b/apps/susidns/src/build.xml
@@ -38,6 +38,7 @@
 
 	<property name="javac.compilerargs" value="" />
 	<property name="javac.version" value="1.8" />
+	<property name="javac.release" value="8" />
 	<property name="require.gettext" value="true" />
 
     <condition property="no.bundle">
@@ -47,6 +48,7 @@
  	<target name="compile">
 		<mkdir dir="${bin}" />
 		<javac debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+			release="${javac.release}"
 			includeAntRuntime="false"
 			encoding="UTF-8"
  			classpathref="cp" destdir="${bin}" srcdir="${src}" includes="**/*.java" >
@@ -92,6 +94,7 @@
             <replacefilter token="${user.dir}/apps/susidns/src/" value="" />
         </replace>
         <javac debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                destdir="${bin}" srcdir="${tmp}" includes="**/*.java" classpathref="cp">
@@ -187,6 +190,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="${bin}">

--- a/apps/susimail/build.xml
+++ b/apps/susimail/build.xml
@@ -8,6 +8,7 @@
 
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="require.gettext" value="true" />
 
     <condition property="no.bundle">
@@ -39,6 +40,7 @@
         <javac 
             srcdir="./src/src"
             debug="true" deprecation="on" source="${javac.version}" target="${javac.version}" 
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./src/WEB-INF/classes">
@@ -136,6 +138,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="src/WEB-INF/classes">

--- a/apps/systray/java/build.xml
+++ b/apps/systray/java/build.xml
@@ -22,6 +22,7 @@
 
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
@@ -32,6 +33,7 @@
             deprecation="on"
             source="${javac.version}"
             target="${javac.version}"
+            release="${javac.release}"
             destdir="./build/obj"
             includeAntRuntime="false"
             encoding="UTF-8"

--- a/build.properties
+++ b/build.properties
@@ -44,6 +44,7 @@ require.gettext=true
 
 # Compile for this version of Java
 #javac.version=1.8
+#javac.release=8
 
 # Additional classpath if required
 #javac.classpath=/PATH/TO/pack200.jar
@@ -66,6 +67,8 @@ require.gettext=true
 # For more info:
 #    http://zzz.i2p/topics/1668
 #    https://gist.github.com/AlainODea/1375759b8720a3f9f094
+#
+# Do NOT set bootclasspath when compiling with Java 9 or higher.
 #
 # For embedded use only, and for a limited time,
 # the following subsystems ONLY may be built with Java 6 by setting javac.version=1.6 in override.properties,

--- a/build.xml
+++ b/build.xml
@@ -2,6 +2,9 @@
 <project basedir="." default="all" name="i2p"
     xmlns:artifact="antlib:org.apache.maven.artifact.ant">
 
+    <!-- for javac "release" parameter -->
+    <property name="ant.minimumVersion" value="1.9.8"/>
+
     <!--
          Include property files so that values can be easily overridden.
          Users should create an override.properties file to make changes.
@@ -329,12 +332,12 @@
         </sequential>
     </target>
 
-    <target name="buildBOB" depends="buildStreaming" >
+    <target name="buildBOB" depends="buildMinistreaming" >
         <ant dir="apps/BOB/" target="jar" />
         <copy file="apps/BOB/dist/BOB.jar" todir="build/" />
     </target>
 
-    <target name="buildSAM" depends="buildStreaming" >
+    <target name="buildSAM" depends="buildMinistreaming" >
         <ant dir="apps/sam/java/" target="jar" />
         <copy file="apps/sam/java/build/sam.jar" todir="build/" />
     </target>
@@ -365,7 +368,7 @@
         <copy file="apps/i2pcontrol/build/jsonrpc.war" todir="build/" />
     </target>
 
-    <target name="buildI2PSnark" depends="buildStreaming, buildJetty, buildSystray" >
+    <target name="buildI2PSnark" depends="buildMinistreaming, buildJetty, buildSystray" >
         <ant dir="apps/i2psnark/java/" target="war" />
         <copy file="apps/i2psnark/i2psnark.war" todir="build/" />
         <copy file="apps/i2psnark/java/build/i2psnark.jar" todir="build/" />
@@ -391,7 +394,7 @@
         <copy file="apps/i2ptunnel/java/build/i2ptunnel-ui.jar" todir="build/" />
     </target>
 
-    <target name="buildI2PTunnel" depends="buildStreaming, buildJetty, buildImagegen" >
+    <target name="buildI2PTunnel" depends="buildMinistreaming, buildJetty, buildImagegen" >
         <ant dir="apps/i2ptunnel/java/" target="build" />
         <copy file="apps/i2ptunnel/java/build/i2ptunnel.jar" todir="build/" />
         <copy file="apps/i2ptunnel/java/build/i2ptunnel.war" todir="build/" />
@@ -450,6 +453,14 @@
     </target>
 
     <target name="buildProperties" depends="getMtnRev, getGitRev, getReleaseNumber, getBuildNumber, setBuildTimestamp, disableManifestClasspath" >
+        <antversion property="antversion"/>
+        <fail message="FATAL: Minimum Ant version is ${ant.minimumVersion} - your Ant version is ${antversion}">
+            <condition>
+                <not>
+                    <antversion atleast="${ant.minimumVersion}"/>
+                </not>
+            </condition>
+        </fail>
         <!-- default if not set above -->
         <property name="workspace.version" value="unknown" />
         <!-- default if not set by setBuildTimestamp -->
@@ -2479,6 +2490,7 @@
             </condition>
         </fail>
         <property name="javac.version" value="1.7" />
+        <property name="javac.release" value="7" />
     </target>
 
     <!-- depends on buildCoreTest so that the router unit test javadocs can find the core unit test classes -->
@@ -2502,6 +2514,7 @@
         <ant dir="apps/jetty/">
             <!-- not used in Android -->
             <property name="javac.version" value="1.8" />
+            <property name="javac.release" value="8" />
             <target name="servletJar" />
             <target name="servletJavadocJar" />
             <target name="servletSourcesJar" />
@@ -2867,11 +2880,11 @@
         </tar>
     </target>
 
-    <!--
-        same as debian-release-tarball but with bundled jetty
-        -  We add a 'p' to the release name and tarball since the source package is different;
-        -  Launchpad does not allow different source packages with the same name.
-    -->
+    <!-- Precise no longer supported, does not work -->
+    <!-- same as debian-release-tarball but with bundled jetty
+      -  We add a 'p' to the release name and tarball since the source package is different;
+      -  Launchpad does not allow different source packages with the same name.
+      -->
     <target name="precise-release-tarball" depends="getExtendedVersion, failIfNoVCS">
         <property name="debian.tarball.name" value="i2p_${release.number}p.orig.tar.bz2" />
         <property name="checkoutDir" value="../i2p-${Extended.Version}" />
@@ -2945,6 +2958,7 @@
         </tar>
     </target>
 
+    <!-- Xenial no longer supported, does not work -->
     <!-- xenial/yakkety only -->
     <!--
         same as debian-release-tarball but with bundled jstl.jar

--- a/core/java/build.xml
+++ b/core/java/build.xml
@@ -23,6 +23,7 @@
     <property name="javac.compilerargs" value="" />
     <property name="javac.classpath" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
     <!-- fixups if we're using libintl.jar for GettextResource.java -->
@@ -77,6 +78,7 @@
         <mkdir dir="./build/obj" />
         <!-- sourcepath="" necessary for excludes to work, see ant manual for javac -->
         <javac sourcepath="" srcdir="./src" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+               release="${javac.release}"
                debuglevel="lines,vars,source"
                includeAntRuntime="false"
                encoding="UTF-8"
@@ -149,6 +151,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="build/obj">
@@ -291,6 +294,7 @@
         <echo message="[DEBUG] junit home after override is ${junit.home}" />
         <echo message="[DEBUG] hamcrest home after override is ${hamcrest.home}" />
         <javac srcdir="./test/junit" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+               release="${javac.release}"
                debuglevel="lines,vars,source"
                includeAntRuntime="true"
                encoding="UTF-8"
@@ -543,6 +547,7 @@
         <mkdir dir="./build" />
         <mkdir dir="./build/obj_bench" />
         <javac srcdir="./bench" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+               release="${javac.release}"
                debuglevel="lines,vars,source"
                includeAntRuntime="false"
                encoding="UTF-8"

--- a/debian-alt/bionic/control
+++ b/debian-alt/bionic/control
@@ -6,7 +6,7 @@ Priority: optional
 Bugs: mailto:zzz@i2pmail.org
 Homepage: https://geti2p.net/
 Build-Depends: debhelper (>= 9.20160709)
- ,ant (>= 1.8)
+ ,ant (>= 1.9.8)
  ,debconf
  ,openjdk-8-jdk
  ,libjetty9-java (>= 9.4)

--- a/debian-alt/bionic/rules
+++ b/debian-alt/bionic/rules
@@ -80,10 +80,11 @@ else
 	@echo "Already found deb in version, not doing anything"
 endif
 	@# build options
+	@/bin/echo -e "javac.release=8" > $(CURDIR)/override.properties
 	@/bin/echo -e "javac.version=1.8" > $(CURDIR)/override.properties
 	@/bin/echo -e "javac.compilerargs=-bootclasspath $(JAVA_HOME)/jre/lib/rt.jar:$(JAVA_HOME)/jre/lib/jce.jar" >> $(CURDIR)/override.properties
 	@/bin/echo -e "javac.compilerargs7=-bootclasspath $(JAVA_HOME)/jre/lib/rt.jar:$(JAVA_HOME)/jre/lib/jce.jar" >> $(CURDIR)/override.properties
-	@/bin/echo -e "build.built-by=debian" >> $(CURDIR)/override.properties
+	@/bin/echo -e "build.built-by=launchpad" >> $(CURDIR)/override.properties
 	@/bin/echo -e "build.reproducible=true" >> $(CURDIR)/override.properties
 
 	@# debian and ubuntu: everywhere

--- a/debian-alt/focal/rules
+++ b/debian-alt/focal/rules
@@ -81,10 +81,8 @@ else
 	@echo "Already found deb in version, not doing anything"
 endif
 	@# build options
-#	@/bin/echo -e "javac.version=1.8" > $(CURDIR)/override.properties
-#	@/bin/echo -e "javac.compilerargs=-bootclasspath $(JAVA_HOME)/jre/lib/rt.jar:$(JAVA_HOME)/jre/lib/jce.jar" >> $(CURDIR)/override.properties
-#	@/bin/echo -e "javac.compilerargs7=-bootclasspath $(JAVA_HOME)/jre/lib/rt.jar:$(JAVA_HOME)/jre/lib/jce.jar" >> $(CURDIR)/override.properties
-	@/bin/echo -e "build.built-by=debian" >> $(CURDIR)/override.properties
+	@/bin/echo -e "javac.release=11" > $(CURDIR)/override.properties
+	@/bin/echo -e "build.built-by=launchpad" >> $(CURDIR)/override.properties
 	@/bin/echo -e "build.reproducible=true" >> $(CURDIR)/override.properties
 
 	@# debian and ubuntu: everywhere

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://geti2p.net/
 Vcs-Browser: https://salsa.debian.org/debian/i2p
 Vcs-Git: https://salsa.debian.org/debian/i2p.git
 Build-Depends: debhelper (>= 9.20160709)
- ,ant (>= 1.8)
+ ,ant (>= 1.9.8)
  ,debconf
  ,default-jdk
  ,libjetty9-java (>= 9.4)

--- a/debian/rules
+++ b/debian/rules
@@ -93,9 +93,7 @@ else
 	@echo "Already found deb in version, not doing anything"
 endif
 	@# build options
-#	@/bin/echo -e "javac.version=1.8" > $(CURDIR)/override.properties
-#	@/bin/echo -e "javac.compilerargs=-bootclasspath $(JAVA_HOME)/jre/lib/rt.jar:$(JAVA_HOME)/jre/lib/jce.jar" >> $(CURDIR)/override.properties
-#	@/bin/echo -e "javac.compilerargs7=-bootclasspath $(JAVA_HOME)/jre/lib/rt.jar:$(JAVA_HOME)/jre/lib/jce.jar" >> $(CURDIR)/override.properties
+	@/bin/echo -e "javac.release=11" > $(CURDIR)/override.properties
 	@/bin/echo -e "build.built-by=debian" >> $(CURDIR)/override.properties
 	@/bin/echo -e "build.reproducible=true" >> $(CURDIR)/override.properties
 

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,11 @@
+2020-10-07 zzz
+ * Build:
+   - Set javac release property (ticket #2775)
+   - Ant version 1.9.8 or higher now required
+   - Drop support for Xenial package build
+   - Fix up BOB build configuration
+   - Fix i2psnark standalone build
+
 2020-10-03 zzz
  * Router: Support building tunnels through ECIES routers (proposal 152)
 

--- a/installer/java/build.xml
+++ b/installer/java/build.xml
@@ -20,11 +20,13 @@
     <property name="javac.compilerargs" value="" />
     <property name="javac.classpath" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
         <mkdir dir="./build/obj" />
         <javac srcdir="./src" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" classpath="${javac.classpath}:../../core/java/build/obj" >

--- a/installer/tools/java/build.xml
+++ b/installer/tools/java/build.xml
@@ -20,11 +20,13 @@
     <property name="javac.compilerargs" value="" />
     <property name="javac.classpath" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
 
     <target name="compile" depends="depend">
         <mkdir dir="./build" />
         <mkdir dir="./build/obj" />
         <javac srcdir="./src" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+            release="${javac.release}"
             includeAntRuntime="false"
             encoding="UTF-8"
             destdir="./build/obj" classpath="${javac.classpath}:../../../build/i2p.jar:../../../core/java/build/gnu-getopt.jar:../../../build/router.jar" >

--- a/router/java/build.xml
+++ b/router/java/build.xml
@@ -37,12 +37,14 @@
     <!-- only used if not set by a higher build.xml -->
     <property name="javac.compilerargs" value="" />
     <property name="javac.version" value="1.8" />
+    <property name="javac.release" value="8" />
     <property name="manifest.classpath.name" value="Class-Path" />
 
     <target name="compile" depends="depend, dependVersion">
         <mkdir dir="./build" />
         <mkdir dir="./build/obj" />
         <javac srcdir="./src" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+               release="${javac.release}"
                debuglevel="lines,vars,source"
                includeAntRuntime="false"
                encoding="UTF-8"
@@ -108,6 +110,7 @@
             <arg value="./bundle-messages.sh" />
         </exec>
         <javac source="${javac.version}" target="${javac.version}" 
+               release="${javac.release}"
                includeAntRuntime="false"
                encoding="UTF-8"
                srcdir="build/messages-src" destdir="build/obj">
@@ -256,6 +259,7 @@
         <property name="hamcrest.home" value="${ant.home}/lib/" />
         <property name="junit.home" value="${ant.home}/lib/" />
         <javac srcdir="./test/junit" debug="true" source="${javac.version}" target="${javac.version}" deprecation="on"
+            release="${javac.release}"
             debuglevel="lines,vars,source"
             includeAntRuntime="true"
             encoding="UTF-8"

--- a/router/java/src/net/i2p/router/RouterVersion.java
+++ b/router/java/src/net/i2p/router/RouterVersion.java
@@ -18,7 +18,7 @@ public class RouterVersion {
     /** deprecated */
     public final static String ID = "Monotone";
     public final static String VERSION = CoreVersion.VERSION;
-    public final static long BUILD = 5;
+    public final static long BUILD = 6;
 
     /** for example "-test" */
     public final static String EXTRA = "+";


### PR DESCRIPTION
Ant version 1.9.8 or higher now required
Drop support for Xenial package build
Fix up BOB build configuration
Fix i2psnark standalone build

(cherry picked from commit a9a5d13e06eaa3aa7dce496f55b710443c5162f0)