### PR TITLE
I2PSnark: Add override.css.purple for midnight theme

### DIFF
--- a/installer/resources/themes/snark/midnight/override.css.purple
+++ b/installer/resources/themes/snark/midnight/override.css.purple
@@ -1,0 +1,7 @@
+/* I2PSnark Midnight theme override (embedded mode) */
+/* Enable console midnight purple override for best results! */
+/* Author: dr|z3d */
+
+.iframed table img, .iframed .toggleview img, .iframed .snarkConfigTitle img, .iframed .snarkTorrentPeerCount b {
+  filter: hue-rotate(-30deg) !important;
+}


### PR DESCRIPTION
Only active in embedded mode, requires midnight console theme + purple override